### PR TITLE
Implement SQL Persistence for Memory

### DIFF
--- a/config/init.sql
+++ b/config/init.sql
@@ -162,3 +162,24 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA lnx_meta GRANT ALL ON TABLES TO memory_p;
 ALTER DEFAULT PRIVILEGES IN SCHEMA meilisearch_meta GRANT ALL ON TABLES TO memory_p;
 ALTER DEFAULT PRIVILEGES IN SCHEMA memorybank_meta GRANT ALL ON TABLES TO memory_p;
 ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT ALL ON TABLES TO memory_p;
+
+-- ==========================================
+-- Memory Persistence Layer
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS public.memory (
+    key TEXT PRIMARY KEY,
+    data JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Trigger for memory table
+DROP TRIGGER IF EXISTS update_memory_updated_at ON public.memory;
+CREATE TRIGGER update_memory_updated_at
+    BEFORE UPDATE ON public.memory
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Permissions
+GRANT ALL PRIVILEGES ON TABLE public.memory TO memory_p;

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,10 @@ pub enum MemoryPError {
 
     #[error("Shared Memory Error: {0}")]
     SharedMemoryError(String),
+
+    #[cfg(feature = "sqlx")]
+    #[error("Database Error: {0}")]
+    Database(#[from] sqlx::Error),
 }
 
 pub type Result<T> = std::result::Result<T, MemoryPError>;

--- a/src/motores/persistence.rs
+++ b/src/motores/persistence.rs
@@ -7,19 +7,65 @@ pub trait PersistenceLayer: Send + Sync {
     async fn load_data(&self, key: &str) -> Result<Option<serde_json::Value>, Box<dyn Error>>;
 }
 
-pub struct PostgresPersistence;
+pub struct PostgresPersistence {
+    #[cfg(feature = "sqlx")]
+    pool: Option<sqlx::PgPool>,
+}
+
+impl PostgresPersistence {
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "sqlx")]
+            pool: None,
+        }
+    }
+
+    #[cfg(feature = "sqlx")]
+    pub fn with_pool(pool: sqlx::PgPool) -> Self {
+        Self { pool: Some(pool) }
+    }
+}
+
 #[async_trait]
 impl PersistenceLayer for PostgresPersistence {
     async fn save_data(
         &self,
-        _key: &str,
-        _value: &serde_json::Value,
+        key: &str,
+        value: &serde_json::Value,
     ) -> Result<(), Box<dyn Error>> {
-        tracing::info!("🐘 Persisting to PostgreSQL (+pgvector): {}", _key);
-        // TODO: SQL: INSERT INTO memory (key, data) VALUES (...) ON CONFLICT ...
+        tracing::info!("🐘 Persisting to PostgreSQL (+pgvector): {}", key);
+
+        #[cfg(feature = "sqlx")]
+        if let Some(pool) = &self.pool {
+            sqlx::query(
+                "INSERT INTO public.memory (key, data) \
+                 VALUES ($1, $2) \
+                 ON CONFLICT (key) DO UPDATE SET \
+                 data = EXCLUDED.data, \
+                 updated_at = CURRENT_TIMESTAMP"
+            )
+            .bind(key)
+            .bind(value)
+            .execute(pool)
+            .await?;
+            return Ok(());
+        }
+
         Ok(())
     }
-    async fn load_data(&self, _key: &str) -> Result<Option<serde_json::Value>, Box<dyn Error>> {
+    async fn load_data(&self, key: &str) -> Result<Option<serde_json::Value>, Box<dyn Error>> {
+        #[cfg(feature = "sqlx")]
+        if let Some(pool) = &self.pool {
+            let row: Option<(serde_json::Value,)> = sqlx::query_as(
+                "SELECT data FROM public.memory WHERE key = $1"
+            )
+            .bind(key)
+            .fetch_optional(pool)
+            .await?;
+
+            return Ok(row.map(|r| r.0));
+        }
+
         Ok(None)
     }
 }


### PR DESCRIPTION
This change replaces the placeholder logic for PostgreSQL persistence with a real implementation using `sqlx`. 

Key improvements:
1. **Schema**: Added a `memory` table to `config/init.sql` with `key`, `data` (JSONB), and timestamp columns.
2. **UPSERT**: The `save_data` method uses an `INSERT ... ON CONFLICT (key) DO UPDATE` statement to efficiently handle updates.
3. **Error Handling**: Integrated `sqlx::Error` into the project's error system.
4. **Optional Dependency**: All database code is guarded by the `sqlx` feature flag to maintain build flexibility.
5. **Clean Code**: Refactored the trait implementation to follow the project's patterns and addressed code review feedback regarding variable naming.

---
*PR created automatically by Jules for task [15715654616582005114](https://jules.google.com/task/15715654616582005114) started by @kimberlyvargas1723-cmd*

## Summary by Sourcery

Implement actual PostgreSQL-backed memory persistence using sqlx with feature-gated integration.

New Features:
- Add a Postgres-backed implementation of the PersistenceLayer trait that can be configured with a sqlx connection pool.
- Introduce a memory table in the database schema for storing JSONB-encoded key/value data with timestamps.

Enhancements:
- Guard database-related code and errors behind the sqlx feature flag to keep the dependency optional.
- Integrate sqlx::Error into the unified MemoryPError error type for consistent database error handling.