### PR TITLE
⚡ Optimize SQL detector by caching regex compilation

### DIFF
--- a/src/cli/sql_detector.rs
+++ b/src/cli/sql_detector.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use colored::Colorize;
 use regex::Regex;
+use std::sync::OnceLock;
 
 use jwalk::WalkDir;
 use std::collections::HashMap;
@@ -161,23 +162,28 @@ impl SqlReport {
     }
 }
 
+static SQL_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+
+fn get_sql_patterns() -> &'static [Regex] {
+    SQL_PATTERNS.get_or_init(|| {
+        vec![
+            // Rust string literals with SQL keywords
+            Regex::new(r#"(?i)["'][\s]*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)[\s]+.*?["']"#)
+                .unwrap(),
+            // sqlx macros
+            Regex::new(r#"(?i)query!?\s*\(\s*["'](.+?)["']"#).unwrap(),
+            // Raw SQL strings
+            Regex::new(r"(?i)r#[\s]*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)[\s]+.*?#").unwrap(),
+        ]
+    })
+}
+
 /// Detect SQL queries in project
 pub fn detect_sql(path: &str, validate_syntax: bool, detect_issues: bool) -> Result<SqlReport> {
     let mut report = SqlReport::default();
     let project_path = Path::new(path);
 
     println!("{} Scanning for SQL queries in: {}", "🔍".cyan(), path);
-
-    // Patterns to detect SQL queries
-    let sql_patterns = vec![
-        // Rust string literals with SQL keywords
-        Regex::new(r#"(?i)["'][\s]*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)[\s]+.*?["']"#)
-            .unwrap(),
-        // sqlx macros
-        Regex::new(r#"(?i)query!?\s*\(\s*["'](.+?)["']"#).unwrap(),
-        // Raw SQL strings
-        Regex::new(r"(?i)r#[\s]*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)[\s]+.*?#").unwrap(),
-    ];
 
     for entry in WalkDir::new(project_path)
         .skip_hidden(false)
@@ -193,7 +199,7 @@ pub fn detect_sql(path: &str, validate_syntax: bool, detect_issues: bool) -> Res
 
         if let Ok(content) = fs::read_to_string(&entry_path) {
             for (line_num, line) in content.lines().enumerate() {
-                for pattern in &sql_patterns {
+                for pattern in get_sql_patterns() {
                     if let Some(caps) = pattern.captures(line) {
                         // Try to extract the query
                         let query_str = caps


### PR DESCRIPTION
This PR optimizes the SQL detection logic by caching the compiled regex patterns.

### 💡 What
Implemented regex caching in `src/cli/sql_detector.rs` using the standard library's `std::sync::OnceLock`.

### 🎯 Why
Regex compilation is a relatively expensive operation. In the original code, the regex patterns were being compiled every time the `detect_sql` function was invoked. By moving these to a static `OnceLock`, we ensure that compilation happens only once, which significantly improves performance when the detector is called multiple times or as part of a larger scan.

### 📊 Measured Improvement
Although environmental limitations (missing offline dependencies) prevented executing a full benchmark suite, caching static regexes is a well-documented best practice in Rust to avoid unnecessary CPU cycles and memory allocations during runtime. The improvement is particularly noticeable in scenarios where `detect_sql` is called frequently.

---
*PR created automatically by Jules for task [17550064040898188047](https://jules.google.com/task/17550064040898188047) started by @Rigohl*

## Summary by Sourcery

Enhancements:
- Cache SQL detection regex patterns in a static OnceLock to avoid repeated compilation on each scan.