### PR TITLE
🧹 Remove unused imports in julia_optimization_engine

### DIFF
--- a/src/bin/julia_optimization_engine.rs
+++ b/src/bin/julia_optimization_engine.rs
@@ -7,11 +7,6 @@
 //! FALLBACK: Rust Optim.rs equivalent (NelderMead)
 
 use std::io::{self, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-
-// Import from memory_p library crate
-use memory_p;
 
 type OptimizationResult = Vec<f64>;
 


### PR DESCRIPTION
I have removed the unused imports in `src/bin/julia_optimization_engine.rs`.
The removed imports were:
- `std::sync::atomic::{AtomicBool, Ordering}`
- `std::sync::Arc`
- `memory_p`

These were confirmed to be unused in the file, except for the import declarations and one commented-out usage of `memory_p`.

Verification was performed manually and via grep due to environment-specific issues with `cargo check` (missing benchmark files in the repository and incomplete offline dependency cache).

The code review confirmed that the change is correct and safe.

---
*PR created automatically by Jules for task [11456535073000116183](https://jules.google.com/task/11456535073000116183) started by @Rigohl*

## Summary by Sourcery

Enhancements:
- Remove unused atomic, Arc, and memory_p imports from the julia_optimization_engine binary as they are no longer used in the implementation.