### PR TITLE
🔒 Remove hardcoded API key and JWT secret fallbacks

### DIFF
--- a/cloudflare-worker.ts
+++ b/cloudflare-worker.ts
@@ -155,7 +155,11 @@ function authenticateRequest(request: Request, env: Env): { valid: boolean; reas
     }
 
     // Get API key from environment (set in wrangler.toml)
-    const expectedKey = env.MEMORY_P_API_KEY || "demo-key-change-in-production";
+    const expectedKey = env.MEMORY_P_API_KEY;
+
+    if (!expectedKey) {
+        return { valid: false, reason: "Server misconfiguration: MEMORY_P_API_KEY is not set" };
+    }
 
     // Check Authorization header
     const authHeader = request.headers.get("Authorization");
@@ -322,7 +326,14 @@ export default {
                 }
 
                 // Create JWT token
-                const secret = env.JWT_SECRET || "dev-secret-change-in-production";
+                const secret = env.JWT_SECRET;
+                if (!secret) {
+                    return new Response(
+                        JSON.stringify({ error: "server_error", error_description: "Server misconfiguration: JWT_SECRET is not set" }),
+                        { status: 500, headers: { "Content-Type": "application/json", ...corsHeaders } }
+                    );
+                }
+
                 const payload: JWTPayload = {
                     sub: client_id,
                     iat: Math.floor(Date.now() / 1000),


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Removed hardcoded security-sensitive fallbacks for `MEMORY_P_API_KEY` and `JWT_SECRET` in `cloudflare-worker.ts`.

⚠️ **Risk:** The potential impact if left unfixed
If left unfixed, the application would fallback to insecure, publicly known default keys ("demo-key-change-in-production") if environment variables were missing. This would allow anyone with knowledge of the default keys to bypass authentication and access the MCP gateway and its underlying microservices.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix removes the hardcoded fallback strings. It adds logic to explicitly check for the presence of `MEMORY_P_API_KEY` during request authentication and `JWT_SECRET` during OAuth token generation. If either is missing, the worker now returns an appropriate error response (401 Unauthorized or 500 Internal Server Error) indicating a server misconfiguration, preventing insecure operation.

---
*PR created automatically by Jules for task [9865384863814688059](https://jules.google.com/task/9865384863814688059) started by @Rigohl*

## Summary by Sourcery

Harden authentication and token generation by removing insecure default secrets and enforcing required environment configuration.

Bug Fixes:
- Eliminate hardcoded fallback values for MEMORY_P_API_KEY to prevent unintended authentication bypass when the environment variable is missing.
- Eliminate hardcoded fallback values for JWT_SECRET to prevent issuance of tokens signed with a known development secret when the environment variable is missing.

Enhancements:
- Add explicit misconfiguration handling by returning clear error responses when MEMORY_P_API_KEY or JWT_SECRET are not set in the environment.