### PR TITLE
Implement Redis Distributed Pub/Sub Synchronization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["development-tools", "utilities"]
 
 [dependencies]
 tokio = { version = "1.40", features = ["full"] }
-futures = "0.3"
 async-trait = "0.1"
 async-stream = "0.3"
 axum = "0.7"
@@ -20,6 +19,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
+futures = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "json"] }
 sled = "0.34"
 qdrant-client = "1.10"
@@ -29,6 +29,7 @@ dashmap = "6.1"
 parking_lot = "0.12"
 rayon = "1.11"
 num_cpus = "1.17"
+redis = { version = "0.24", features = ["tokio-comp", "connection-manager"] }
 scc = "2.4"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.22", features = ["v4", "v5", "serde"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,8 @@ pub struct AdvancedConfig {
     pub enable_zerocopy: bool,
     /// Activar caché de análisis con SCC
     pub enable_scc_cache: bool,
+    /// URL de Redis para pub/sub distribuido
+    pub redis_url: String,
 }
 
 /// Configuración del orquestador Julia
@@ -50,6 +52,7 @@ impl Default for AdvancedConfig {
             large_file_threshold: 10 * 1024 * 1024, // 10MB
             enable_zerocopy: true,
             enable_scc_cache: true,
+            redis_url: "redis://127.0.0.1:6379".to_string(),
         }
     }
 }

--- a/src/shared_memory/mod.rs
+++ b/src/shared_memory/mod.rs
@@ -27,7 +27,7 @@ impl SharedMemorySystem {
 
     pub async fn new() -> Result<Self> {
         let manager = Arc::new(ContextManager::new().await?);
-        let sync = Arc::new(sync::SyncCoordinator::new().await?);
+        let sync = Arc::new(sync::SyncCoordinator::new());
 
         // Inicializar el coordinador de sincronización
         sync.initialize().await?;

--- a/src/shared_memory/sync.rs
+++ b/src/shared_memory/sync.rs
@@ -3,12 +3,15 @@
 use super::types::{AgentId, ContextId, SharedContext};
 use crate::error::Result;
 use dashmap::DashMap;
+use futures::StreamExt;
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::broadcast;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 
 /// Evento de sincronización
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SyncEvent {
     /// Contexto actualizado
     ContextUpdated {
@@ -47,14 +50,27 @@ impl SyncEvent {
     }
 }
 
+/// Envoltorio para eventos de Redis que incluye el ID de instancia
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RedisSyncEvent {
+    pub source_instance: uuid::Uuid,
+    pub event: SyncEvent,
+}
+
 /// Coordinador de sincronización entre agentes
 /// Utiliza pub/sub para notificar cambios a todos los agentes interesados
 pub struct SyncCoordinator {
+    /// ID único de esta instancia
+    instance_id: uuid::Uuid,
+
     /// Canal de broadcast para eventos
     event_tx: broadcast::Sender<SyncEvent>,
 
     /// Suscriptores activos por agente
     subscribers: Arc<DashMap<AgentId, broadcast::Receiver<SyncEvent>>>,
+
+    /// Conexión de Redis para publicación
+    redis_tx: Arc<tokio::sync::Mutex<Option<redis::aio::MultiplexedConnection>>>,
 
     /// Indica si está inicializado
     initialized: Arc<std::sync::atomic::AtomicBool>,
@@ -62,15 +78,17 @@ pub struct SyncCoordinator {
 
 impl SyncCoordinator {
     /// Crea un nuevo coordinador de sincronización
-    pub async fn new() -> Result<Self> {
+    pub fn new() -> Self {
         // Canal con capacidad para 1000 eventos
         let (event_tx, _) = broadcast::channel(1000);
 
-        Ok(Self {
+        Self {
+            instance_id: uuid::Uuid::new_v4(),
             event_tx,
             subscribers: Arc::new(DashMap::new()),
+            redis_tx: Arc::new(tokio::sync::Mutex::new(None)),
             initialized: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        })
+        }
     }
 
     /// Inicializa el coordinador
@@ -79,15 +97,86 @@ impl SyncCoordinator {
             return Ok(());
         }
 
-        info!("🔧 Inicializando coordinador de sincronización");
+        info!(
+            "🔧 Inicializando coordinador de sincronización (ID: {})",
+            self.instance_id
+        );
 
-        // TODO: Conectar a Redis para pub/sub distribuido
-        // let redis_client = connect_to_redis().await.ok();
+        // Conectar a Redis para pub/sub distribuido
+        let redis_url = &crate::config::CONFIG.advanced.redis_url;
+        match redis::Client::open(redis_url.as_str()) {
+            Ok(client) => {
+                match client.get_multiplexed_async_connection().await {
+                    Ok(conn) => {
+                        let mut redis_tx = self.redis_tx.lock().await;
+                        *redis_tx = Some(conn);
+                        info!("📡 Conectado a Redis para publicación distribuida");
+
+                        // Iniciar suscriptor en background
+                        self.start_redis_subscriber(client).await;
+                    }
+                    Err(e) => {
+                        warn!("⚠️ No se pudo conectar a Redis: {}. El modo distribuido estará desactivado.", e);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "⚠️ URL de Redis inválida ({}): {}. El modo distribuido estará desactivado.",
+                    redis_url, e
+                );
+            }
+        }
 
         self.initialized
             .store(true, std::sync::atomic::Ordering::Release);
         info!("✅ Coordinador de sincronización inicializado");
         Ok(())
+    }
+
+    /// Inicia el suscriptor de Redis en una tarea separada
+    async fn start_redis_subscriber(&self, client: redis::Client) {
+        let event_tx = self.event_tx.clone();
+        let instance_id = self.instance_id;
+
+        tokio::spawn(async move {
+            match client.get_async_connection().await {
+                Ok(conn) => {
+                    let mut pubsub = conn.into_pubsub();
+                    if let Err(e) = pubsub.subscribe("memory_p_sync").await {
+                        error!("❌ Error al suscribirse a canal Redis: {}", e);
+                        return;
+                    }
+
+                    info!("📥 Suscrito a eventos distribuidos en 'memory_p_sync'");
+
+                    let mut stream = pubsub.on_message();
+                    while let Some(msg) = stream.next().await {
+                        let payload: Vec<u8> = match msg.get_payload() {
+                            Ok(p) => p,
+                            Err(e) => {
+                                error!("❌ Error al leer payload de Redis: {}", e);
+                                continue;
+                            }
+                        };
+
+                        if let Ok(redis_event) = serde_json::from_slice::<RedisSyncEvent>(&payload) {
+                            // Ignorar eventos generados por nosotros mismos
+                            if redis_event.source_instance != instance_id {
+                                debug!(
+                                    "Recibido evento remoto de instancia {}",
+                                    redis_event.source_instance
+                                );
+                                let _ = event_tx.send(redis_event.event);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Error en conexión de suscripción Redis: {}", e);
+                }
+            }
+        });
     }
 
     /// Suscribe un agente a eventos de sincronización
@@ -118,17 +207,34 @@ impl SyncCoordinator {
             targets,
         };
 
-        match self.event_tx.send(event) {
+        // 1. Enviar localmente
+        match self.event_tx.send(event.clone()) {
             Ok(num_receivers) => {
-                debug!("Evento enviado a {} suscriptores", num_receivers);
-                Ok(())
+                debug!("Evento enviado a {} suscriptores locales", num_receivers);
             }
             Err(_) => {
-                // No hay receptores activos, no es un error
-                debug!("Sin suscriptores activos para evento");
-                Ok(())
+                debug!("Sin suscriptores activos locales para evento");
             }
         }
+
+        // 2. Enviar a Redis para distribución
+        let mut redis_tx_lock = self.redis_tx.lock().await;
+        if let Some(conn) = redis_tx_lock.as_mut() {
+            let redis_event = RedisSyncEvent {
+                source_instance: self.instance_id,
+                event,
+            };
+
+            if let Ok(payload) = serde_json::to_vec(&redis_event) {
+                if let Err(e) = conn.publish::<_, _, ()>("memory_p_sync", payload).await {
+                    error!("❌ Error al publicar evento en Redis: {}", e);
+                } else {
+                    debug!("Evento publicado en Redis");
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Sincroniza contextos entre agentes específicos
@@ -169,8 +275,10 @@ impl SyncCoordinator {
 impl Clone for SyncCoordinator {
     fn clone(&self) -> Self {
         Self {
+            instance_id: self.instance_id,
             event_tx: self.event_tx.clone(),
             subscribers: Arc::clone(&self.subscribers),
+            redis_tx: Arc::clone(&self.redis_tx),
             initialized: Arc::clone(&self.initialized),
         }
     }
@@ -182,13 +290,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_coordinator_creation() {
-        let coordinator = SyncCoordinator::new().await.unwrap();
+        let coordinator = SyncCoordinator::new();
         assert!(coordinator.initialize().await.is_ok());
     }
 
     #[tokio::test]
+    async fn test_redis_unreachable_initialization() {
+        // La inicialización debería tener éxito incluso si Redis no está disponible
+        let coordinator = SyncCoordinator::new();
+        // Usamos una URL que probablemente no tenga un Redis escuchando
+        // Aunque la prueba es offline, el cliente de redis simplemente fallará al conectar
+        // y el código debería manejarlo con un warning.
+        let result = coordinator.initialize().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn test_subscribe_unsubscribe() {
-        let coordinator = SyncCoordinator::new().await.unwrap();
+        let coordinator = SyncCoordinator::new();
         coordinator.initialize().await.unwrap();
 
         let agent_id = AgentId::new("test-agent".to_string());
@@ -202,7 +321,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_broadcast_update() {
-        let coordinator = SyncCoordinator::new().await.unwrap();
+        let coordinator = SyncCoordinator::new();
         coordinator.initialize().await.unwrap();
 
         let agent_id = AgentId::new("test-agent".to_string());
@@ -237,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_selective_sync() {
-        let coordinator = SyncCoordinator::new().await.unwrap();
+        let coordinator = SyncCoordinator::new();
         coordinator.initialize().await.unwrap();
 
         let source_agent = AgentId::new("source".to_string());


### PR DESCRIPTION
This change enables distributed synchronization of context events across multiple instances of the memory system using Redis Pub/Sub.

Key changes:
1. **Dependency Management**: Added `redis` (with `tokio-comp` and `connection-manager` features) and `futures` crates.
2. **Configuration**: Added `redis_url` to `AdvancedConfig` in `src/config.rs`, defaulting to `redis://127.0.0.1:6379`.
3. **Synchronization Logic**:
   - `SyncCoordinator` now generates a unique `instance_id` (UUID) upon creation.
   - `initialize()` attempts to connect to Redis. If successful, it starts a background task that listens for events on the `memory_p_sync` channel.
   - Events received from Redis are ignored if they originated from the same `instance_id`.
   - `broadcast_update()` now publishes serialized events to Redis in addition to local broadcasting.
4. **Resilience**: The system gracefully falls back to local-only synchronization if Redis is unreachable, logging a warning instead of failing.
5. **Code Quality**: Switched to `MultiplexedConnection` for publishing to allow better concurrency and simplified the `SyncCoordinator::new` API back to synchronous.

---
*PR created automatically by Jules for task [132233390260021780](https://jules.google.com/task/132233390260021780) started by @Rigohl*

## Summary by Sourcery

Add Redis-based distributed synchronization for shared memory context events while maintaining local-only operation as a fallback.

New Features:
- Introduce a Redis-backed distributed pub/sub layer for propagating SyncEvent updates across instances using a shared channel.
- Add per-instance UUIDs to SyncCoordinator events to support filtering out self-originated Redis messages.
- Expose a configurable Redis connection URL in AdvancedConfig with a sensible local default.

Enhancements:
- Refactor SyncCoordinator to be constructed synchronously and to manage a multiplexed Redis connection for concurrent publishing.
- Extend SyncEvent to be serializable for transport over Redis and wrap it in a RedisSyncEvent envelope carrying source metadata.
- Launch a background Redis subscriber task that forwards remote events into the existing local broadcast channel.

Build:
- Add redis (with async features) and futures dependencies to enable asynchronous Redis pub/sub integration.

Tests:
- Add tests ensuring SyncCoordinator initializes successfully even when Redis is unreachable and adjust existing tests to the new synchronous constructor.