### PR TITLE
⚡ Optimize vector search batch operations to use native async concurrency

### DIFF
--- a/src/motores/vector_search/advanced_engine.rs
+++ b/src/motores/vector_search/advanced_engine.rs
@@ -272,12 +272,11 @@ impl AdvancedVectorEngine {
 
     /// Indexa múltiples documentos en paralelo
     pub async fn index_batch(&self, docs: Vec<VectorDocument>) -> Result<usize> {
-        use rayon::prelude::*;
+        let futures = docs
+            .into_iter()
+            .map(|doc| self.index_document(doc));
 
-        let results: Vec<Result<()>> = docs
-            .into_par_iter()
-            .map(|doc| futures::executor::block_on(self.index_document(doc)))
-            .collect();
+        let results = futures::future::join_all(futures).await;
 
         let success_count = results.iter().filter(|r| r.is_ok()).count();
 
@@ -345,12 +344,11 @@ impl AdvancedVectorEngine {
         limit: usize,
         filter: Option<VectorFilter>,
     ) -> Result<Vec<Vec<VectorSearchResult>>> {
-        use rayon::prelude::*;
+        let futures = query_vectors
+            .iter()
+            .map(|qv| self.search(qv, limit, filter.clone()));
 
-        let results: Vec<Result<Vec<VectorSearchResult>>> = query_vectors
-            .par_iter()
-            .map(|qv| futures::executor::block_on(self.search(qv, limit, filter.clone())))
-            .collect();
+        let results = futures::future::join_all(futures).await;
 
         results.into_iter().collect()
     }


### PR DESCRIPTION
The optimization addresses a "Synchronous I/O in Async Context / Blocking Thread Pool" issue in `src/motores/vector_search/advanced_engine.rs`.

Specifically:
- In `index_batch`, replaced Rayon's `into_par_iter` and `block_on(self.index_document(doc))` with `futures::future::join_all`.
- In `search_batch`, replaced Rayon's `par_iter` and `block_on(self.search(...))` with `futures::future::join_all`.

These changes ensure that batch operations do not block the async executor threads, improving overall system throughput and preventing potential deadlocks.

---
*PR created automatically by Jules for task [2614139388718438393](https://jules.google.com/task/2614139388718438393) started by @Rigohl*

## Summary by Sourcery

Enhancements:
- Update batch indexing and search operations to use async join_all over futures instead of Rayon parallel iterators and blocking executors.